### PR TITLE
[WIP] Add support for multiple arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can also instruct the script to only log to the console by passing a second 
 ```javascript
 console.log("foo"); //Logs to HTML
 console.log("bar", true); // Logs to the console, but only if logToConsole is set to true
-````
+```
 
 ## Customisation
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ npm install console-log-html --save
 You can also instruct the script to only log to the console by passing a second argument to `console.*()`, e.g.:
 
 ```javascript
-console.log("foo"); //Logs to HTML
-console.log("bar", true); // Logs to the console, but only if logToConsole is set to true
+console.log("foo"); //Logs "foo" to HTML
+console.log("Look, some JSON:", {foo: 'bar'}); //Logs "Look, some JSON: Object {"foo":"bar"}" to HTML
+console.skipHtml.log("bar"); // Logs to the console, but only if logToConsole is set to true !!!!!!!!!!!!!!TO BE REVIEWED !!!!!!!!!!!!!!
 ```
 
 ## Customisation

--- a/console-log-html.js
+++ b/console-log-html.js
@@ -38,7 +38,8 @@ var ConsoleLogHTML = (function (original, methods, console, Object, TYPE_UNDEFIN
                     finalMsg = msg.toString();
                     if (finalMsg === INSTANCE_OBJECT_OBJECT) {
                         try {
-                            finalMsg = JSON.stringify(msg);
+                            // Prefix with "Object" like in Firefox-, Chrome-, and node.js-output
+                            finalMsg = "Object " + JSON.stringify(msg);
                         } catch (e) {
 
                         }

--- a/console-log-html.js
+++ b/console-log-html.js
@@ -35,7 +35,7 @@ var ConsoleLogHTML = (function (original, methods, console, Object, TYPE_UNDEFIN
                     onlyConsole = false;
                 }
                 if (!onlyConsole) {
-                    finalMsg = msg.toString();
+                    finalMsg = msg + ""; // "safe toString()" (works with null & undefined)
                     if (finalMsg === INSTANCE_OBJECT_OBJECT) {
                         try {
                             // Prefix with "Object" like in Firefox-, Chrome-, and node.js-output

--- a/test/test-logger.js
+++ b/test/test-logger.js
@@ -29,6 +29,8 @@ describe("Test logging", function () {
             expect(1).toBe(li.innerText.match(pat).length);
             expect(li.className).toBe(ConsoleLogHTML.DEFAULTS[levels[i]]);
             expect(TARGET_UL.children.length).toBe(i + 1);
+
+            expect(console.skipHtml[levels[i]]).toBeDefined();
         }
     });
 });
@@ -45,10 +47,12 @@ describe("Test clear", function () {
 describe("Test no timestamp", function () {
     it("Disconnect", function () {
         console.clear();
-        ConsoleLogHTML.disconnect();
+        expect(console.skipHtml).toBeDefined();
         expect(TARGET_UL).toBeEmpty();
+        ConsoleLogHTML.disconnect();
         console.debug("Disconnect");
         expect(TARGET_UL).toBeEmpty();
+        expect(console.skipHtml).toBeUndefined(); // prove that `skipHtml` is being reset
     });
 
     it("Reconnect", function () {
@@ -60,14 +64,14 @@ describe("Test no timestamp", function () {
     });
 });
 
-describe("Test onlyToConsole", function () {
+describe("Test skipHtml", function () {
     it("onlyToConsole", function () {
         console.clear();
-        console.debug("onlyToConsole1");
+        console.debug("skipHtml 1");
         expect(TARGET_UL).not.toBeEmpty();
         console.clear();
         expect(TARGET_UL).toBeEmpty();
-        console.debug("onlyToConsole2", true);
+        console.skipHtml.debug("skipHtml 2");
         expect(TARGET_UL).toBeEmpty();
     });
 });
@@ -115,6 +119,25 @@ describe("Test Obj", function () {
         console.debug(testObj);
 
         var expected = "my custom toString() impl";
+        expect(TARGET_UL.firstElementChild.innerText).toBe(expected);
+    });
+});
+
+describe("Test multiple arguments", function () {
+    it("concatenates all arguments", function () {
+        console.debug("str", 42, true);
+
+        var expected = "str 42 true";
+        expect(TARGET_UL.firstElementChild.innerText).toBe(expected);
+    });
+
+    it("formats all objects to JSON", function () {
+        var testObj1 = {foo: "1"};
+        var testObj2 = {foo: "2"};
+
+        console.debug(testObj1, testObj2);
+
+        var expected = "Object " + JSON.stringify(testObj1) + " Object " + JSON.stringify(testObj2);
         expect(TARGET_UL.firstElementChild.innerText).toBe(expected);
     });
 });

--- a/test/test-logger.js
+++ b/test/test-logger.js
@@ -73,12 +73,13 @@ describe("Test onlyToConsole", function () {
 });
 
 describe("Test Obj", function () {
-    it("test jsonable", function () {
-        var testObj = {foo: "bar"},
-            testStr = JSON.stringify(testObj);
+    it("formats to JSON", function () {
+        var testObj = {foo: "bar"};
 
         console.debug(testObj);
-        expect(TARGET_UL.firstElementChild.innerText).toBe(testStr);
+
+        var expected = JSON.stringify(testObj);
+        expect(TARGET_UL.firstElementChild.innerText).toBe(expected);
     });
 
     it("test nonJsonable", function () {
@@ -100,7 +101,21 @@ describe("Test Obj", function () {
         };
         inst = new Clazz();
         console.debug(inst);
-        expect(TARGET_UL.firstElementChild.innerText).toBe(JSON.stringify(inst));
+        var expected = JSON.stringify(inst);
+        expect(TARGET_UL.firstElementChild.innerText).toBe(expected);
+    });
+
+    it("with custom toString()", function () {
+        var testObj = {
+            toString: function () {
+                return "my custom toString() impl";
+            }
+        };
+
+        console.debug(testObj);
+
+        var expected = "my custom toString() impl";
+        expect(TARGET_UL.firstElementChild.innerText).toBe(expected);
     });
 });
 

--- a/test/test-logger.js
+++ b/test/test-logger.js
@@ -119,6 +119,20 @@ describe("Test Obj", function () {
     });
 });
 
+describe("Test special values", function () {
+    it("formats null to string", function () {
+        console.debug(null);
+
+        expect(TARGET_UL.firstElementChild.innerText).toBe("null");
+    });
+
+    it("formats undefined to string", function () {
+        console.debug(undefined);
+
+        expect(TARGET_UL.firstElementChild.innerText).toBe("undefined");
+    });
+});
+
 describe("Connect jQuery", function () {
     it("Disconnect", function () {
         console.clear();

--- a/test/test-logger.js
+++ b/test/test-logger.js
@@ -78,7 +78,7 @@ describe("Test Obj", function () {
 
         console.debug(testObj);
 
-        var expected = JSON.stringify(testObj);
+        var expected = "Object " + JSON.stringify(testObj);
         expect(TARGET_UL.firstElementChild.innerText).toBe(expected);
     });
 
@@ -101,7 +101,7 @@ describe("Test Obj", function () {
         };
         inst = new Clazz();
         console.debug(inst);
-        var expected = JSON.stringify(inst);
+        var expected = "Object " + JSON.stringify(inst);
         expect(TARGET_UL.firstElementChild.innerText).toBe(expected);
     });
 


### PR DESCRIPTION
Fixes #1.

### TODO
- [ ] Discuss a slight behavior change I've added. Previously, if `logToConsole`-option was false, we suppressed logging (completely) when `onlyConsole=true`. I've changed that, so that now `console.skipHtml` does _not_ suppress logging even when `logToConsole`-option is `false`. Is this OK? If not, the `logToConsole`-check simply has to be moved into the `console.skipHtml[method]` function.
- [ ] Finish README update.
- [ ] Run dist script & commit results.
- [ ] Update version.

If I run `npm run dist` on master (without changes) with the latest npm packages, I get a lot of changes in the jsdoc files. Same on your machine?

How can I trigger a [CI run for the PR](https://travis-ci.org/Alorel/console-log-html/pull_requests)?